### PR TITLE
Fix filetree structure in scanner.mdx

### DIFF
--- a/pages/guides/scanner.mdx
+++ b/pages/guides/scanner.mdx
@@ -25,9 +25,9 @@ The ideal layout is:
     <FileTree.Folder name="Specials" defaultOpen>
       <FileTree.File name="Artbook 1.cbz" />
     </FileTree.Folder>
-    </FileTree.Folder>
+  </FileTree.Folder>
   
-    <FileTree.Folder name="Series Name B" defaultOpen>
+  <FileTree.Folder name="Series Name B" defaultOpen>
     <FileTree.File name="Series Name B - v01.cbz" />
     <FileTree.File name="Series Name B - v02.cbz" />
     <FileTree.File name="Series Name B - v03.cbz" />
@@ -35,7 +35,7 @@ The ideal layout is:
       <FileTree.File name="Artbook 1.cbz" />
     </FileTree.Folder>
   </FileTree.Folder>
-  </FileTree.Folder>
+</FileTree.Folder>
 </FileTree>
 
 This means you can also have:
@@ -44,26 +44,25 @@ This means you can also have:
 <FileTree.Folder name="Library Root" defaultOpen>
   <FileTree.Folder name="Publisher A" defaultOpen>
     <FileTree.Folder name="Series Name A" defaultOpen>
-    <FileTree.File name="Series Name A - v01.cbz" />
-    <FileTree.File name="Series Name A - v02.cbz" />
-    <FileTree.File name="Series Name A - v03.cbz" />
+      <FileTree.File name="Series Name A - v01.cbz" />
+      <FileTree.File name="Series Name A - v02.cbz" />
+      <FileTree.File name="Series Name A - v03.cbz" />
     </FileTree.Folder>
     <FileTree.Folder name="Series Name B" defaultOpen>
       <FileTree.File name="Oneshot.cbz" />
-    
     </FileTree.Folder>
   </FileTree.Folder>
-  </FileTree.Folder>
-    <FileTree.Folder name="Publisher B" defaultOpen>
-        <FileTree.Folder name="Series Name C" defaultOpen>
-            <FileTree.File name="Series Name C - v01.cbz" />
-            <FileTree.File name="Series Name C - v02.cbz" />
-            <FileTree.File name="Series Name C - v03.cbz" />
-            </FileTree.Folder>
-        <FileTree.Folder name="Series D" defaultOpen>
-        <FileTree.File name="Artbook 1.cbz" />
-            </FileTree.Folder>
+  <FileTree.Folder name="Publisher B" defaultOpen>
+    <FileTree.Folder name="Series Name C" defaultOpen>
+      <FileTree.File name="Series Name C - v01.cbz" />
+      <FileTree.File name="Series Name C - v02.cbz" />
+      <FileTree.File name="Series Name C - v03.cbz" />
     </FileTree.Folder>
+    <FileTree.Folder name="Series D" defaultOpen>
+      <FileTree.File name="Artbook 1.cbz" />
+    </FileTree.Folder>
+  </FileTree.Folder>
+</FileTree.Folder>
 </FileTree>
 
 If these rules are followed, you shouldn't have any problems.
@@ -89,11 +88,11 @@ If these rules are followed, you shouldn't have any problems.
 <FileTree.Folder name="Library Root" defaultOpen>
   <FileTree.Folder name="Series Name A" defaultOpen>
     <FileTree.File name="Series Name A - v01.cbz" />
-    </FileTree.Folder>
-    <FileTree.Folder name="Series Name A" defaultOpen>
+  </FileTree.Folder>
+  <FileTree.Folder name="Series Name A" defaultOpen>
     <FileTree.File name="Series Name A - v02.cbz" />
   </FileTree.Folder>
-  </FileTree.Folder>
+</FileTree.Folder>
 </FileTree>
 
 


### PR DESCRIPTION
Fix the broken filetree structure in `pages/guides/scanner.mdx`.
